### PR TITLE
Fix join slack

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 - add iter as alias for itergrs in pr. namespace
 - gr.length() shows nucleotide length (sum of all interval lengths)
 - gr.lengths() takes as_dict=False flag to return as vector
+- fix slack in join: added columns when joining with itself
 
 # 0.0.57 (10.10.19)
 - add overlap-flag to tile

--- a/pyranges/explore/time_k_nearest.py
+++ b/pyranges/explore/time_k_nearest.py
@@ -1,0 +1,7 @@
+
+# kernprof -l time_k_nearest.py && python -m line_profiler time_k_nearest.py.lprof
+import pyranges as pr
+from os.path import expanduser
+nrows = int(2e5)
+gr = pr.read_bed(expanduser("~/ucsc2.bed.gz"), nrows=nrows)
+gr.knearest(gr, k=1)

--- a/pyranges/pyranges.py
+++ b/pyranges/pyranges.py
@@ -812,13 +812,7 @@ class PyRanges():
 
     def mspc(self, n=30, formatting=None):
 
-        print(
-            tostring(
-                self,
-                n=n,
-                merge_position=True,
-                sort=True,
-                formatting=formatting))
+        print(tostring(self, n=n, merge_position=True, sort=True, formatting=formatting))
 
         return self
 

--- a/pyranges/pyranges.py
+++ b/pyranges/pyranges.py
@@ -812,7 +812,13 @@ class PyRanges():
 
     def mspc(self, n=30, formatting=None):
 
-        print(tostring(self, n=n, merge_position=True, sort=True, formatting=formatting))
+        print(
+            tostring(
+                self,
+                n=n,
+                merge_position=True,
+                sort=True,
+                formatting=formatting))
 
         return self
 

--- a/pyranges/pyranges.py
+++ b/pyranges/pyranges.py
@@ -255,7 +255,7 @@ class PyRanges():
         if slack:
             gr.Start = gr.Start__slack
             gr.End = gr.End__slack
-            gr = gr.drop("Start__slack End__slack".split())
+            gr = gr.drop(like="(Start|End).*__slack")
 
         new_position = kwargs.get("new_pos")
         if new_position:


### PR DESCRIPTION
If a, b in join(a, b, slack=x) was same pyranges, left some additional cols 