### PR TITLE
Fixing typo in docs

### DIFF
--- a/docs/subsetting-pyranges.html
+++ b/docs/subsetting-pyranges.html
@@ -172,7 +172,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <h1><span class="header-section-number">4</span> Subsetting PyRanges</h1>
 <p>There are many ways to subset a PyRanges object. Each returns a new PyRanges object and does not change the old one.</p>
 <p>For data exploration, the functions head, tail and sample (random choice without
-replacment) are convenient. They take an argument n to denote how many entries
+replacement) are convenient. They take an argument n to denote how many entries
 you want.</p>
 <div class="sourceCode" id="cb46"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb46-1" data-line-number="1"></a>
 <a class="sourceLine" id="cb46-2" data-line-number="2"><span class="im">import</span> pyranges <span class="im">as</span> pr</a>


### PR DESCRIPTION
Thanks for the great documentation - it looks like I'll use this module a lot. I fixed a typo.