### PR TITLE
Changes to to_row_gff3() to work with Ensembl GFF3 files.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,7 @@
 - remove FDR from fisher_exact, but add fdr as own method in stats
 - make stats.mcc faster
 - make stats.mcc work without a genome
+- fix gff3 reading when metadata contains spaces
 
 # 0.0.62 (11.11.19)
 - fix fisher exact when given pd.Series

--- a/pyranges/readers.py
+++ b/pyranges/readers.py
@@ -234,8 +234,8 @@ def read_gtf_restricted(f,
 def to_rows_gff3(anno):
     rowdicts = []
     for l in list(anno):
-        l = l.replace(";", " ").replace("=", " ").split()
-        rowdicts.append({k: v for k, v in zip(*([iter(l)] * 2))})
+        l = ( it.split("=") for it in l.split(";") )
+        rowdicts.append({k: v for k, v in l})
 
     return pd.DataFrame.from_dict(rowdicts).set_index(anno.index)
 


### PR DESCRIPTION
Hi,
I noticed that `read_gff3()` takes a very long time when parsing Ensembl annotation (such as ftp://ftp.ensembl.org/pub/release-98/gff3/mus_musculus/Mus_musculus.GRCm38.98.chromosome.X.gff3.gz). I noticed that reading in this file results in almost 2000 annotation columns and realised that the reason is that `to_rows_gff3()` doesn't correctly handle cases where there are spaces in attribute values. I made a small change which I think fixes this.

Cheers,
Greg