### PR TITLE
multiple attribute in gtf file

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 - fix small bug in jaccard
 - remove leftover debug-print in pr.random()
 - add experimental gr.stats.forbes
+- support for multiple (repeating) attributes in gtf reading
 
 # 0.0.72 (03.02.20)
 - random also takes dict as chromsizes argument (like {"chr1": 249, "chr2": 242})

--- a/pyranges/readers.py
+++ b/pyranges/readers.py
@@ -62,7 +62,6 @@ def read_bam(f, sparse=True, output_df=False, mapq=0, required_flag=0, filter_fl
         except AttributeError:
             print("bamread version 0.0.6 or higher is required to read bam non-sparsely.")
 
-
     if output_df:
         return df
     else:
@@ -174,7 +173,14 @@ def to_rows(anno):
     rowdicts = []
     for l in anno:
         l = l.replace('"', '').replace(";", "").split()
-        rowdicts.append({k: v for k, v in zip(*([iter(l)] * 2))})
+
+        row = dict()
+        for k, v in zip(*([iter(l)] * 2)):
+            if k in row:
+                row[k] = [row[k], v]
+            else:
+                row[k] = v
+        rowdicts.append(row)
 
     return pd.DataFrame.from_dict(rowdicts).set_index(anno.index)
 
@@ -239,6 +245,7 @@ def read_gtf_restricted(f,
     else:
         return df
 
+
 def to_rows_gff3(anno):
     rowdicts = []
 
@@ -252,7 +259,6 @@ def to_rows_gff3(anno):
 
 
 def read_gff3(f, annotation=None, output_df=False, nrows=None, skiprows=0):
-
     """seqid - name of the chromosome or scaffold; chromosome names can be given with or without the 'chr' prefix. Important note: the seq ID must be one used within Ensembl, i.e. a standard chromosome name or an Ensembl identifier such as a scaffold ID, without any additional content such as species or assembly. See the example GFF output below.
 source - name of the program that generated this feature, or the data source (database or project name)
 type - type of feature. Must be a term or accession from the SOFA sequence ontology
@@ -282,7 +288,6 @@ attributes - A semicolon-separated list of tag-value pairs, providing additional
         chunksize=int(1e5),
         skiprows=skiprows,
         nrows=nrows)
-
 
     dfs = []
     for df in df_iter:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -15,7 +15,18 @@ def test_read_gtf():
     assert transcript['tag'] == 'basic'
 
     exon = df[df['exon_id'] == 'ENSE00003812156'].iloc[0]
-    assert exon['tag'] == ['CCDS', 'basic']
+    assert exon['tag'] == 'basic'
+
+    gr = pr.read_gtf("tests/test_data/ensembl.gtf",
+                     full=True, duplicate_attr=True)
+    assert len(gr.columns) == 28
+
+    df = gr.df
+    transcript = df.iloc[1]
+    assert transcript['tag'] == 'basic'
+
+    exon = df[df['exon_id'] == 'ENSE00003812156'].iloc[0]
+    assert exon['tag'] == 'CCDS,basic'
     # assert list(gr.df.columns[:4]) == "Chromosome Start End Strand".split()
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -10,6 +10,12 @@ def test_read_gtf():
     gr = pr.read_gtf("tests/test_data/ensembl.gtf", full=True)
     assert len(gr.columns) == 28
 
+    df = gr.df
+    transcript = df.iloc[1]
+    assert transcript['tag'] == 'basic'
+
+    exon = df[df['exon_id'] == 'ENSE00003812156'].iloc[0]
+    assert exon['tag'] == ['CCDS', 'basic']
     # assert list(gr.df.columns[:4]) == "Chromosome Start End Strand".split()
 
 


### PR DESCRIPTION
In a gtf file, attributes may repeat. For example, `tag` attribute repeats in the example below:  

GTF row:
1	havana	exon	65419	65433	.	+	.	gene_id "ENSG00000186092"; gene_version "5"; transcript_id "ENST00000641515"; transcript_version "1"; exon_number "1"; gene_name "OR4F5"; gene_source "ensembl_havana"; gene_biotype "protein_coding"; transcript_name "OR4F5-202"; transcript_source "havana"; transcript_biotype "protein_coding"; **tag "CCDS";** ccds_id "CCDS30547"; exon_id "ENSE00003812156"; exon_version "1"; **tag "basic";**

Current `read_gtf` functions overwrite repeated attributes. This PR fixes this issue with returning list for repeating attributes.
