### PR TITLE
Add pretty printing for Jupyter notebooks

### DIFF
--- a/pyranges/pyranges.py
+++ b/pyranges/pyranges.py
@@ -488,6 +488,13 @@ class PyRanges():
         return str(self)
 
 
+    def _repr_html_(self):
+
+        """Return REPL HTML representation for Jupyter Noteboooks."""
+
+        return self.df._repr_html_()
+
+
 
     def apply(self, f, strand=None, as_pyranges=True, nb_cpu=1, **kwargs):
 


### PR DESCRIPTION
This modification automatically displays PyRanges objects as the underlying pandas DataFrame object's HTML representation in Jupyter notebooks.
It addresses #146.