### PR TITLE
fixes: #262; nearest without overlapping chromosomes

### DIFF
--- a/pyranges/methods/nearest.py
+++ b/pyranges/methods/nearest.py
@@ -1,4 +1,3 @@
-
 import pandas as pd
 
 

--- a/pyranges/methods/nearest.py
+++ b/pyranges/methods/nearest.py
@@ -28,7 +28,7 @@ def _insert_distance(ocdf, dist, suffix):
 
 
 def _overlapping_for_nearest(scdf, ocdf, suffix):
-  
+
     nearest_df = pd.DataFrame(columns="Chromosome Start End Strand".split())
 
     scdf2, ocdf2 = _both_dfs(scdf, ocdf, how="first")

--- a/pyranges/methods/nearest.py
+++ b/pyranges/methods/nearest.py
@@ -28,6 +28,7 @@ def _insert_distance(ocdf, dist, suffix):
 
 
 def _overlapping_for_nearest(scdf, ocdf, suffix):
+  
     nearest_df = pd.DataFrame(columns="Chromosome Start End Strand".split())
 
     scdf2, ocdf2 = _both_dfs(scdf, ocdf, how="first")

--- a/pyranges/methods/nearest.py
+++ b/pyranges/methods/nearest.py
@@ -1,3 +1,4 @@
+
 import pandas as pd
 
 
@@ -28,7 +29,6 @@ def _insert_distance(ocdf, dist, suffix):
 
 
 def _overlapping_for_nearest(scdf, ocdf, suffix):
-
     nearest_df = pd.DataFrame(columns="Chromosome Start End Strand".split())
 
     scdf2, ocdf2 = _both_dfs(scdf, ocdf, how="first")
@@ -82,8 +82,10 @@ def _previous_nonoverlapping(left_starts, right_ends):
 
 def _nearest(scdf, ocdf, **kwargs):
 
-    if scdf.empty or ocdf.empty:
+    if scdf.empty:
         return None
+    if ocdf.empty:
+        return scdf
 
     overlap = kwargs["overlap"]
     how = kwargs["how"]


### PR DESCRIPTION
I'm not sure what a good way of solving this would be? This _kinda_ works. In that it doesn't output a working PyRanges. It however does output a valid dataframe from the PyRanges. 

Example of how this breaks pyranges

```
import pyranges

f1 = pyranges.from_dict({'Chromosome': ['chr1', 'chr2'], 'Start': [3, 8], 'End': [6, 9]})
f2 = pyranges.from_dict({'Chromosome': ['chr1'], 'Start': [1], 'End': [2]})

print("--------")

print(f1.nearest(f2).Distance)
```

Which gives a keyerror, as not each chromosome non-NA values...