### PR TITLE
added step to reorder bed columns based on order in PyRanges object before writing

### DIFF
--- a/pyranges/out.py
+++ b/pyranges/out.py
@@ -32,6 +32,7 @@ def _bed(df, keep):
     outdf = _fill_missing(df, all_columns)
 
     noncanonical = set(df.columns) - set(all_columns)
+    noncanonical = [c for c in df.columns if c in noncanonical]
 
     if keep:
         return pd.concat([outdf, df.get(noncanonical)], axis=1)


### PR DESCRIPTION
`_bed`  in `out.py` uses set operations to separate canonical (bed6) columns from all other columns. This creates inconsistent behaviour in the order that the 7th+ columns are saved in the output bed file. I added a line to retain the original ordering of the columns in the PyRanges object  before saving. 