### PR TITLE
A small update to remove pd.append() warnings

### DIFF
--- a/pyranges/methods/join.py
+++ b/pyranges/methods/join.py
@@ -84,8 +84,8 @@ def _both_dfs(scdf, ocdf, how=False):
         sh.index = [-1]
         oh.index = [-1]
 
-        scdf = scdf.append(sh)
-        ocdf = ocdf.append(oh)
+        scdf = pd.concat([scdf, sh])
+        ocdf = pd.concat([ocdf, oh])
 
         scdf = scdf.reindex(_self_indexes)
         ocdf = ocdf.reindex(_other_indexes)


### PR DESCRIPTION
Panda pd.append() is deprecated. You may see the corresponding announcement [here](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.append.html):

I simply replaced this function with pd.concat() which is now recommended.
The result will be identical, but without a warning.