### PR TITLE
Fix FutureWarning

### DIFF
--- a/pyranges/methods/split.py
+++ b/pyranges/methods/split.py
@@ -23,8 +23,8 @@ def _split(df, **kwargs):
 
     _ends = points.shift(-1)
 
-    points = points[:-1]
-    _ends = _ends[:-1]
+    points = points.iloc[:-1]
+    _ends = _ends.iloc[:-1]
     features = pd.concat([points, _ends], axis=1).astype(dtype)
     features.columns = "Start End".split()
 


### PR DESCRIPTION
split.py:26: FutureWarning: The behavior of `series[i:j]` with an integer-dtype index is deprecated. In a future version, this will be treated as *label-based* indexing, consistent with e.g. `series[i]` lookups. To retain the old behavior, use `series.iloc[i:j]`. To get the future behavior, use `series.loc[i:j]`.
  points = points[:-1]