### PR TITLE
updated links to v0/v1 using Codex + manual review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# pyranges
+# pyranges0
 
-[![Coverage Status](https://img.shields.io/coveralls/github/biocore-ntnu/pyranges.svg)](https://coveralls.io/github/biocore-ntnu/pyranges?branch=master) [![hypothesis tested](graphs/hypothesis-tested-brightgreen.svg)](http://hypothesis.readthedocs.io/) [![PyPI version](https://badge.fury.io/py/pyranges.svg)](https://badge.fury.io/py/pyranges) [![MIT](https://img.shields.io/pypi/l/pyranges.svg?color=green)](https://opensource.org/licenses/MIT) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyranges.svg) [![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](http://bioconda.github.io/recipes/pyranges/README.html)
+## Deprecation note!
+
+This repo currently hosts the "version 0" of pyranges. A redesigned, faster version 1 is available at https://github.com/pyranges/pyranges1
+Version 1 will soon replace version 0. We encourage existing v0 users to migrate to v1 (see guide at https://pyranges1.readthedocs.io/en/latest/migration_guide.html), and new users to directly adopt v1. Read about v1 in our preprint at https://doi.org/10.64898/2025.12.11.693639
 
 ## Introduction
 
@@ -10,14 +13,9 @@ The library is optimized for fast querying and manipulation of genomic annotatio
 
 *"Finally ... This was what Python badly needed for years."* - Heng Li
 
-## Deprecation note!
-This repo currently hosts the "version 0" of pyranges. A redesigned, faster version1 is available at https://github.com/pyranges/pyranges_1.x
-Version 1 will soon replace version 0. We encourage existing v0 users to migrate to v1 (see guide at https://pyranges1.readthedocs.io/en/latest/migration_guide.html), and new users to directly adopt v1. Read about v1 in our preprint at https://doi.org/10.64898/2025.12.11.693639
-
-
 ## Documentation
 
-The pyranges documentation, including installation instructions, API, tutorial, and how-to-pages, of version 0 is available at <https://pyranges.readthedocs.io/>
+The pyranges0 documentation, including installation instructions, API, tutorial, and how-to pages, is available at <https://pyranges0.readthedocs.io/en/latest/>
 
 ## Features
 
@@ -41,10 +39,9 @@ Stovner EB, Sætrom P (2020) PyRanges: efficient comparison of genomic intervals
 
 ## Asking for help
 
-If you encounter bugs, or the documentation is not enough a cannot accomplish a specific task of interest, or if you'd like new features implemented, open an Issue at github: https://github.com/pyranges/pyranges/issues
+If you encounter bugs, or the documentation is not enough and you cannot accomplish a specific task of interest, or if you'd like new features implemented, open an issue on GitHub: https://github.com/pyranges/pyranges0/issues
 
 ## Contributing to pyranges
 
-Pyranges accepts code contributions in form of pull request. For details, visit [https://pyranges.readthedocs.io/developer_guide.html](https://pyranges.readthedocs.io/en/latest/developer_guide.html)
-
+Pyranges accepts code contributions in the form of pull requests. For details, visit [https://pyranges0.readthedocs.io/en/latest/developer_guide.html](https://pyranges0.readthedocs.io/en/latest/developer_guide.html)
 

--- a/book/index.Rmd
+++ b/book/index.Rmd
@@ -45,5 +45,4 @@ The PyRanges documentation is structured in three parts:
 
 1. The tutorial, on the next page, recommended for all new users
 2. The how-to pages, further below, where functionalities are grouped by topic
-3. The [API reference](https://pyranges.readthedocs.io/), where all methods are explained in detail
-
+3. The [API reference](https://pyranges0.readthedocs.io/en/latest/), where all methods are explained in detail

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -3,7 +3,7 @@ Developer guide
 
 PyRanges is mainly developed by Endre Bakken Stovner and by the Comparative Genomics lab of 
 Marco Mariotti. It follows the guidelines for open source software, and external contributors 
-are welcome. The code is centralized on github, at https://github.com/pyranges/pyranges
+are welcome. The code is centralized on GitHub, at https://github.com/pyranges/pyranges0
 
 Bugs and feature requests can be reported as github issues. You may also contribute by submitting 
 your own code edits, either to deal with issues or to add new functionalities. The code will be 
@@ -38,8 +38,8 @@ Documentation: docstrings
 
 Python docstrings are widely used to document the rationale, input arguments, and returned values of 
 all functions and methods. The use of a consistent docstring style allows the automatic generation 
-of API documentation, as seen in pyranges documentation at `https://pyranges.readthedocs.io/ 
-<https://pyranges.readthedocs.io/>`_, built through the Sphynx software.
+of API documentation, as seen in the pyranges0 documentation at `https://pyranges0.readthedocs.io/ 
+<https://pyranges0.readthedocs.io/>`_, built through the Sphinx software.
 
 Pyranges adopts the NumPy/SciPy-style: `https://numpydoc.readthedocs.io/en/latest/format.html 
 <https://numpydoc.readthedocs.io/en/latest/format.html>`_. It is important that code contributors 
@@ -90,8 +90,8 @@ automated documentation:
 2. Create and setup your own PyRanges fork
 ------------------------------------------
 
-The easiest way to do this is through github. Login into the github website if you aren't already, 
-then visit `https://github.com/pyranges/pyranges <https://github.com/pyranges/pyranges>`_, and 
+The easiest way to do this is through GitHub. Login into the GitHub website if you aren't already, 
+then visit `https://github.com/pyranges/pyranges0 <https://github.com/pyranges/pyranges0>`_, and 
 click "Fork" on the top right. Fill the form and confirm. In the page of your new fork, find the 
 **<> Code** button, and copy the https address. On your computer, create a new folder dedicated 
 to the project, then clone your fork inside it:
@@ -102,14 +102,14 @@ to the project, then clone your fork inside it:
 	cd pr_debug
 	git clone PASTE_GITHUB_HTTPS
 
-Next, cd into your pyranges fork, and install it locally with pip as shown below. By using pip 
+Next, cd into your pyranges0 fork, and install it locally with pip as shown below. By using pip 
 option ``-e``, your installation is in "editable" mode: any changes you make to your pyranges code 
 will be immediately reflected in your environment. In other words, you won't need to re-run pip 
 install every time you change something in the code.
 
 .. code:: bash
 
-	cd pyranges
+	cd pyranges0
 	pip install -e .
 
 
@@ -125,7 +125,7 @@ imports pyranges, making sure you're in the prdev conda environment.
 4. Format and lint code
 -----------------------
 
-Run these commands from inside your pyranges folder (which has a pyranges subfolder):
+Run these commands from inside your pyranges0 folder (which has a pyranges subfolder):
 
 .. code:: bash
 
@@ -139,7 +139,7 @@ Run these commands from inside your pyranges folder (which has a pyranges subfol
 
 Your code edits may warrant edits in the pyranges docstrings. In this case, it is compelling to 
 locally check that the automatically generated documentation is built appropriately. Inside the 
-pyranges folder, run these commands:
+pyranges0 folder, run these commands:
 
 .. code:: bash 
 	
@@ -148,7 +148,7 @@ pyranges folder, run these commands:
 	cd -
 
 If the "make" command has no major errors, it will generate the full pyranges documentation in the 
-form of html pages, identical to `https://pyranges.readthedocs.io/ <https://pyranges.readthedocs.io/>`_. 
+form of html pages, identical to `https://pyranges0.readthedocs.io/ <https://pyranges0.readthedocs.io/>`_. 
 Open the file docs/build/html/index.html with a browser to inspect all the parts that may have 
 been affected by your changes, and fix any potential problems. To know more about its inner workings, 
 read about the Sphynx system.
@@ -229,19 +229,19 @@ Finally, push to your remote repository, i.e. update your online fork at github,
 
 	git push
 
-You will be requested your github credentials. Note that your online password may not work; in this 
-case, google how to set up a github token that you can use.
+You will be requested your GitHub credentials. Note that your online password may not work; in this 
+case, search how to set up a GitHub token that you can use.
 
 
 9. Open a pull request
 ----------------------
 
 The easiest way to open a pull request is through the github website. Go to **your** 
-pyranges fork on github, then find the "Contribute" button (near the **<> Code** button). Click 
+pyranges fork on GitHub, then find the "Contribute" button (near the **<> Code** button). Click 
 it, and select **Open pull request**.
 
 In the newly opened page, carefully check that source and destination are correctly selected. The 
-Base repository should be pyranges/pyranges (i.e. the main pyranges repo), and the Head repository 
+Base repository should be pyranges/pyranges0 (i.e. the main pyranges repo), and the Head repository 
 should be your fork. If you worked on non-master git branches, select them here.
 
 In the comments, write a summary of the introduced changes and their rationale, tagging any related 
@@ -256,7 +256,7 @@ Every now and then, the core development team considers that a new pyranges vers
 released. To do so:
 
 - Update the version number in the pyproject.toml file
-- Find the "Build and upload to PyPI" workflow in the left menu of the github actions at `https://github.com/pyranges/pyranges/actions/ <https://github.com/pyranges/pyranges/actions/>`_
+- Find the "Build and upload to PyPI" workflow in the left menu of the GitHub actions at `https://github.com/pyranges/pyranges0/actions/ <https://github.com/pyranges/pyranges0/actions/>`_
 - Click the "Run workflow" button on the right
 
 Next, check that everything worked correctly, by confirming that a new pyranges installation via 

--- a/docs/how_to_book_old_version.rst
+++ b/docs/how_to_book_old_version.rst
@@ -6,7 +6,7 @@ How-to-book
 Introduction to PyRanges
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-This is the PyRanges tutorial. For docs, see: `https://pyranges.readthedocs.io/en/latest/`
+This is the PyRanges tutorial. For docs, see: `https://pyranges0.readthedocs.io/en/latest/`
 
 
 .. contents:: Contents of How-to pages
@@ -1314,6 +1314,5 @@ RLEs: run length encodings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 [outline as advanced usage. Put everything related to RLEs in a single chapter; keep as last even if you add further chapters]
-
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ PyRanges is a Python library specifically designed for efficient and intuitive m
 particularly genomic intervals (like genes, genomic features, or reads).
 The library is optimized for fast querying and manipulation of genomic annotations.
 
-PyRanges is open source, and hosted at github: https://github.com/pyranges/pyranges
+PyRanges is open source, and hosted at GitHub: https://github.com/pyranges/pyranges0
 
 
 Citation
@@ -30,7 +30,7 @@ Documentation outline
 Asking for help
 ~~~~~~~~~~~~~~~
 
-If you encounter bugs, or the documentation is not enough a cannot accomplish a specific task of interest, or if you'd like new features implemented, open an Issue at github: https://github.com/pyranges/pyranges/issues
+If you encounter bugs, or the documentation is not enough and you cannot accomplish a specific task of interest, or if you'd like new features implemented, open an issue on GitHub: https://github.com/pyranges/pyranges0/issues
 
 
 .. toctree::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,4 @@ where = ["."]
 inputs = ['pyranges']
 
 [project.urls]
-Homepage="http://github.com/pyranges/pyranges"
+Homepage="https://github.com/pyranges/pyranges0"


### PR DESCRIPTION
Switching to consistent names: pyranges0 vs pyranges1

The only inconsistency remaining: pip install pyranges still installs v0
While RTD https://pyranges.readthedocs.io/ points to v1 documentation